### PR TITLE
feat: add oneway-pingpong test

### DIFF
--- a/thriftrpc/normalcall/normalcall_test.go
+++ b/thriftrpc/normalcall/normalcall_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cloudwego/kitex-tests/thriftrpc"
 	"github.com/cloudwego/kitex/client"
 	"github.com/cloudwego/kitex/client/callopt"
+	"github.com/cloudwego/kitex/pkg/connpool"
 	"github.com/cloudwego/kitex/pkg/kerrors"
 	"github.com/cloudwego/kitex/transport"
 )
@@ -134,6 +135,18 @@ func TestVisitOneway(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 	test.Assert(t, atomic.LoadInt32(&thriftrpc.CheckNum) == int32(3))
+}
+
+func TestOnewayPingPongByTurns(t *testing.T) {
+	cli := getKitexClient(transport.TTHeaderFramed, client.WithLongConnection(connpool.IdleConfig{MaxIdlePerAddress: 10, MaxIdleGlobal: 1000, MaxIdleTimeout: time.Second * 3}))
+	ctx, stReq := thriftrpc.CreateSTRequest(context.Background())
+	stReq.MockCost = &(&struct{ x string }{x: "300ms"}).x
+	err := cli.VisitOneway(ctx, stReq)
+	test.Assert(t, err == nil, err)
+
+	ctx, stReq = thriftrpc.CreateSTRequest(context.Background())
+	_, err = cli.TestSTReq(ctx, stReq, callopt.WithRPCTimeout(time.Millisecond*300))
+	test.Assert(t, err == nil, err)
 }
 
 func TestRPCTimeoutPriority(t *testing.T) {

--- a/thriftrpc/server.go
+++ b/thriftrpc/server.go
@@ -122,6 +122,13 @@ var CheckNum int32
 
 func (*STServiceHandler) VisitOneway(ctx context.Context, req *stability.STRequest) (err error) {
 	atomic.AddInt32(&CheckNum, 1)
+	if req.MockCost != nil {
+		if mockSleep, err := time.ParseDuration(*req.MockCost); err != nil {
+			return err
+		} else {
+			time.Sleep(mockSleep)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
feat

#### What this PR does / why we need it (en: English/zh: Chinese):
en: add a test that sends oneway and ping-pong requests by turns
zh: 增加轮流进行 oneway 和 ping-pong 调用的测试

#### Which issue(s) this PR fixes:
none
