### PR TITLE
test: server processing timeout

### DIFF
--- a/thriftrpc/normalcall/server_processing_timeout_test.go
+++ b/thriftrpc/normalcall/server_processing_timeout_test.go
@@ -1,0 +1,206 @@
+// Copyright 2024 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package normalcall
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/kitex/client"
+	"github.com/cloudwego/kitex/client/callopt"
+	"github.com/cloudwego/kitex/pkg/kerrors"
+	"github.com/cloudwego/kitex/pkg/remote"
+	remote_transmeta "github.com/cloudwego/kitex/pkg/remote/transmeta"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/transmeta"
+	"github.com/cloudwego/kitex/server"
+	"github.com/cloudwego/kitex/transport"
+
+	"github.com/cloudwego/kitex-tests/common"
+	"github.com/cloudwego/kitex-tests/kitex_gen/thrift/stability"
+	"github.com/cloudwego/kitex-tests/pkg/test"
+	"github.com/cloudwego/kitex-tests/thriftrpc"
+)
+
+type timeoutHandler struct {
+	stability.STService
+	testSTReq func(context.Context, *stability.STRequest) (*stability.STResponse, error)
+}
+
+func (t *timeoutHandler) TestSTReq(ctx context.Context, req *stability.STRequest) (r *stability.STResponse, err error) {
+	return t.testSTReq(ctx, req)
+}
+
+var _ remote.MetaHandler = (*timeoutMetaHandler)(nil)
+
+type timeoutMetaHandler struct {
+	timeout time.Duration
+}
+
+// WriteMeta implements remote.MetaHandler, for client to set timeout.
+func (t *timeoutMetaHandler) WriteMeta(ctx context.Context, msg remote.Message) (context.Context, error) {
+	if t.timeout > 0 {
+		hd := map[uint16]string{
+			remote_transmeta.RPCTimeout: strconv.Itoa(int(t.timeout.Milliseconds())),
+		}
+		msg.TransInfo().PutTransIntInfo(hd)
+	}
+	return ctx, nil
+}
+
+// ReadMeta implements remote.MetaHandler, for server to get timeout.
+func (t *timeoutMetaHandler) ReadMeta(ctx context.Context, msg remote.Message) (context.Context, error) {
+	if t.timeout > 0 {
+		ri := msg.RPCInfo()
+		if cfg := rpcinfo.AsMutableRPCConfig(ri.Config()); cfg != nil {
+			_ = cfg.SetRPCTimeout(t.timeout)
+		}
+	}
+	return ctx, nil
+}
+
+func TestServerProcessingTimeout(t *testing.T) {
+	t.Run("both-ttheader-meta-handler/not-enabled", func(t *testing.T) {
+		svr := thriftrpc.RunServer(&thriftrpc.ServerInitParam{Network: "tcp", Address: serverTimeoutAddr},
+			&timeoutHandler{
+				testSTReq: func(ctx context.Context, request *stability.STRequest) (*stability.STResponse, error) {
+					_, ok := ctx.Deadline()
+					test.Assert(t, !ok)
+
+					time.Sleep(time.Millisecond * 50)
+					return &stability.STResponse{Str: request.Str}, nil
+				},
+			},
+			server.WithMetaHandler(transmeta.ServerTTHeaderHandler),
+			// server.WithEnableContextTimeout(false), // disable by default
+		)
+		common.WaitServer(serverTimeoutAddr)
+		defer svr.Stop()
+
+		cli := getKitexClient(transport.TTHeaderFramed, client.WithMetaHandler(transmeta.ClientTTHeaderHandler))
+		ctx, stReq := thriftrpc.CreateSTRequest(context.Background())
+
+		_, err := cli.TestSTReq(ctx, stReq, callopt.WithHostPort(serverTimeoutAddr))
+		test.Assert(t, err == nil, err)
+	})
+
+	t.Run("both-ttheader-meta-handler/enabled", func(t *testing.T) {
+		svr := thriftrpc.RunServer(&thriftrpc.ServerInitParam{Network: "tcp", Address: serverTimeoutAddr},
+			&timeoutHandler{
+				testSTReq: func(ctx context.Context, request *stability.STRequest) (*stability.STResponse, error) {
+					ddl, ok := ctx.Deadline()
+					test.Assert(t, ok)
+					test.Assert(t, ddl.After(time.Now()))
+
+					time.Sleep(time.Millisecond * 50)
+					return &stability.STResponse{Str: request.Str}, nil
+				},
+			},
+			server.WithMetaHandler(transmeta.ServerTTHeaderHandler),
+			server.WithEnableContextTimeout(true),
+		)
+		common.WaitServer(serverTimeoutAddr)
+		defer svr.Stop()
+
+		cli := getKitexClient(transport.TTHeaderFramed, client.WithMetaHandler(transmeta.ClientTTHeaderHandler))
+		ctx, stReq := thriftrpc.CreateSTRequest(context.Background())
+
+		_, err := cli.TestSTReq(ctx, stReq, callopt.WithHostPort(serverTimeoutAddr), callopt.WithRPCTimeout(time.Millisecond*10))
+		test.Assert(t, errors.Is(err, kerrors.ErrRPCTimeout), err)
+	})
+
+	t.Run("client-set-ttheader/server-ttheader-meta-handler/not-enabled", func(t *testing.T) {
+		svr := thriftrpc.RunServer(&thriftrpc.ServerInitParam{Network: "tcp", Address: serverTimeoutAddr},
+			&timeoutHandler{
+				testSTReq: func(ctx context.Context, request *stability.STRequest) (*stability.STResponse, error) {
+					_, ok := ctx.Deadline()
+					test.Assert(t, !ok)
+
+					time.Sleep(time.Millisecond * 50)
+					return &stability.STResponse{Str: request.Str}, nil
+				},
+			},
+			server.WithMetaHandler(transmeta.ServerTTHeaderHandler),
+			// server.WithEnableContextTimeout(false), // default is false
+		)
+		common.WaitServer(serverTimeoutAddr)
+		defer svr.Stop()
+
+		cli := getKitexClient(transport.TTHeaderFramed, client.WithMetaHandler(&timeoutMetaHandler{
+			timeout: time.Millisecond * 10,
+		}))
+		ctx, stReq := thriftrpc.CreateSTRequest(context.Background())
+
+		_, err := cli.TestSTReq(ctx, stReq, callopt.WithHostPort(serverTimeoutAddr))
+		test.Assert(t, err == nil, err)
+	})
+
+	t.Run("client-set-timeout/server-ttheader-meta-handler/enabled", func(t *testing.T) {
+		svr := thriftrpc.RunServer(&thriftrpc.ServerInitParam{Network: "tcp", Address: serverTimeoutAddr},
+			&timeoutHandler{
+				testSTReq: func(ctx context.Context, request *stability.STRequest) (*stability.STResponse, error) {
+					ddl, ok := ctx.Deadline()
+					test.Assert(t, ok)
+					test.Assert(t, ddl.After(time.Now()))
+
+					time.Sleep(time.Millisecond * 50)
+					return &stability.STResponse{Str: request.Str}, nil
+				},
+			},
+			server.WithMetaHandler(transmeta.ServerTTHeaderHandler),
+			server.WithEnableContextTimeout(true),
+		)
+		common.WaitServer(serverTimeoutAddr)
+		defer svr.Stop()
+
+		cli := getKitexClient(transport.TTHeaderFramed, client.WithMetaHandler(&timeoutMetaHandler{
+			timeout: time.Millisecond * 10,
+		}))
+		ctx, stReq := thriftrpc.CreateSTRequest(context.Background())
+
+		_, err := cli.TestSTReq(ctx, stReq, callopt.WithHostPort(serverTimeoutAddr))
+		test.Assert(t, err == nil, err) // no timeout control in both client and server
+	})
+
+	t.Run("client-not-set/server-set-timeout/enabled", func(t *testing.T) {
+		svr := thriftrpc.RunServer(&thriftrpc.ServerInitParam{Network: "tcp", Address: serverTimeoutAddr},
+			&timeoutHandler{
+				testSTReq: func(ctx context.Context, request *stability.STRequest) (*stability.STResponse, error) {
+					ddl, ok := ctx.Deadline()
+					test.Assert(t, ok)
+					test.Assert(t, ddl.After(time.Now()))
+
+					time.Sleep(time.Millisecond * 50)
+					return &stability.STResponse{Str: request.Str}, nil
+				},
+			},
+			server.WithMetaHandler(&timeoutMetaHandler{
+				timeout: time.Millisecond * 10,
+			}),
+			server.WithEnableContextTimeout(true),
+		)
+		common.WaitServer(serverTimeoutAddr)
+		defer svr.Stop()
+
+		cli := getKitexClient(transport.TTHeaderFramed)
+		ctx, stReq := thriftrpc.CreateSTRequest(context.Background())
+
+		_, err := cli.TestSTReq(ctx, stReq, callopt.WithHostPort(serverTimeoutAddr))
+		test.Assert(t, err == nil, err) // no timeout control in both client and server
+	})
+}

--- a/thriftrpc/server.go
+++ b/thriftrpc/server.go
@@ -21,14 +21,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cloudwego/kitex/pkg/limit"
+	"github.com/cloudwego/kitex/server"
+
 	"github.com/cloudwego/kitex-tests/kitex_gen/thrift/instparam"
 	"github.com/cloudwego/kitex-tests/kitex_gen/thrift/stability"
 	"github.com/cloudwego/kitex-tests/kitex_gen/thrift/stability/stservice"
 	instparam_slim "github.com/cloudwego/kitex-tests/kitex_gen_slim/thrift/instparam"
 	stability_slim "github.com/cloudwego/kitex-tests/kitex_gen_slim/thrift/stability"
 	stservice_slim "github.com/cloudwego/kitex-tests/kitex_gen_slim/thrift/stability/stservice"
-	"github.com/cloudwego/kitex/pkg/limit"
-	"github.com/cloudwego/kitex/server"
 )
 
 var (
@@ -91,6 +92,7 @@ func generateServerOptionsFromParam(param *ServerInitParam, opts ...server.Optio
 		panic(err)
 	}
 
+	opts = append(opts, server.WithExitWaitTime(time.Millisecond*10))
 	opts = append(opts, server.WithServiceAddr(addr))
 	opts = append(opts, server.WithLimit(&limit.Option{
 		MaxConnections: 30000, MaxQPS: 300000, UpdateControl: func(u limit.Updater) {},
@@ -173,7 +175,7 @@ func (h *STServiceHandler) CircuitBreakTest(ctx context.Context, req *stability.
 type STServiceSlimHandler struct{}
 
 func (S *STServiceSlimHandler) VisitOneway(ctx context.Context, req *stability_slim.STRequest) (err error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
test

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
