### PR TITLE
test: add tests for generic write container/sepcify IDL Service per call/compat for old Stream MW

### DIFF
--- a/generic/binarypb/generic_test.go
+++ b/generic/binarypb/generic_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/cloudwego/kitex/client"
+	"github.com/cloudwego/kitex/client/callopt"
+	"github.com/cloudwego/kitex/client/callopt/streamcall"
 	"github.com/cloudwego/kitex/client/genericclient"
 	"github.com/cloudwego/kitex/pkg/generic"
 	"github.com/cloudwego/kitex/server/genericserver"
@@ -223,4 +225,122 @@ func TestBidiStreamingV1(t *testing.T) {
 	err = resp.Unmarshal(res.([]byte))
 	test.Assert(t, err == nil)
 	test.Assert(t, resp.Message == "hello world")
+}
+
+func TestGenericCallWithIDLService(t *testing.T) {
+	protocols := []transport.Protocol{transport.TTHeader, transport.GRPC, transport.GRPCStreaming | transport.TTHeader, transport.TTHeaderStreaming | transport.TTHeader}
+	for _, protocol := range protocols {
+		t.Run(protocol.String(), func(t *testing.T) {
+			// client created with an invalid IDL service name
+			genericClient := newGenericClient(generic.BinaryPbGeneric("ClientSideIDLService", packageName),
+				genericAddr.String(), client.WithTransportProtocol(protocol))
+
+			args := mock.UnaryTestArgs{Req: &pbapi.MockReq{Message: "hello world"}}
+			buf, _ := args.Marshal(nil)
+
+			_, err := genericClient.GenericCall(context.Background(), "UnaryTest", buf)
+			test.Assert(t, err != nil)
+
+			res, err := genericClient.GenericCall(context.Background(), "UnaryTest", buf,
+				callopt.WithBinaryGenericIDLService(serviceName))
+			test.Assert(t, err == nil, err)
+
+			result := &mock.UnaryTestResult{}
+			err = result.Unmarshal(res.([]byte))
+			test.Assert(t, err == nil)
+			test.Assert(t, result.Success.Message == "hello world")
+		})
+	}
+}
+
+func TestStreamingGenericCallWithIDLService(t *testing.T) {
+	// TTHeader Streaming now does not support pb
+	protocols := []transport.Protocol{transport.GRPCStreaming | transport.TTHeader, transport.GRPC}
+	for _, protocol := range protocols {
+		t.Run(protocol.String(), func(t *testing.T) {
+			// client created with an invalid IDL service name
+			genericClient := newGenericClient(generic.BinaryPbGeneric("ClientSideIDLService", packageName),
+				genericAddr.String(), client.WithTransportProtocol(protocol))
+
+			t.Run("BidiStreamingWithoutSpecifying", func(t *testing.T) {
+				stream, err := genericClient.BidirectionalStreaming(context.Background(), "BidirectionalStreamingTest")
+				test.Assert(t, err == nil, err)
+				req := &pbapi.MockReq{Message: "hello world"}
+				buf, _ := req.Marshal(nil)
+				err = stream.Send(stream.Context(), buf)
+				test.Assert(t, err == nil, err)
+				err = stream.CloseSend(stream.Context())
+				test.Assert(t, err == nil, err)
+				_, err = stream.Recv(stream.Context())
+				test.Assert(t, err != nil)
+			})
+			t.Run("ClientStreamingWithoutSpecifying", func(t *testing.T) {
+				stream, err := genericClient.ClientStreaming(context.Background(), "ClientStreamingTest")
+				test.Assert(t, err == nil, err)
+				req := &pbapi.MockReq{Message: "hello world"}
+				buf, _ := req.Marshal(nil)
+				err = stream.Send(stream.Context(), buf)
+				test.Assert(t, err == nil, err)
+				_, err = stream.CloseAndRecv(stream.Context())
+				test.Assert(t, err != nil)
+			})
+			t.Run("ServerStreamingWithoutSpecifying", func(t *testing.T) {
+				req := &pbapi.MockReq{Message: "hello world"}
+				buf, _ := req.Marshal(nil)
+				stream, err := genericClient.ServerStreaming(context.Background(), "ServerStreamingTest", buf)
+				test.Assert(t, err == nil, err)
+				_, err = stream.Recv(stream.Context())
+				test.Assert(t, err != nil)
+			})
+			t.Run("BidiStreamingWithSpecifying", func(t *testing.T) {
+				stream, err := genericClient.BidirectionalStreaming(context.Background(), "BidirectionalStreamingTest",
+					streamcall.WithBinaryGenericIDLService(serviceName))
+				test.Assert(t, err == nil, err)
+				req := &pbapi.MockReq{Message: "hello world"}
+				buf, _ := req.Marshal(nil)
+				err = stream.Send(stream.Context(), buf)
+				test.Assert(t, err == nil, err)
+				err = stream.CloseSend(stream.Context())
+				test.Assert(t, err == nil, err)
+				res, err := stream.Recv(stream.Context())
+				test.Assert(t, err == nil, err)
+				resp := &pbapi.MockResp{}
+				err = resp.Unmarshal(res.([]byte))
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Message == "hello world", resp)
+				_, err = stream.Recv(stream.Context())
+				test.Assert(t, err == io.EOF)
+			})
+			t.Run("ClientStreamingWithSpecifying", func(t *testing.T) {
+				stream, err := genericClient.ClientStreaming(context.Background(), "ClientStreamingTest",
+					streamcall.WithBinaryGenericIDLService(serviceName))
+				test.Assert(t, err == nil, err)
+				req := &pbapi.MockReq{Message: "hello world"}
+				buf, _ := req.Marshal(nil)
+				err = stream.Send(stream.Context(), buf)
+				test.Assert(t, err == nil, err)
+				res, err := stream.CloseAndRecv(stream.Context())
+				test.Assert(t, err == nil, err)
+				resp := &pbapi.MockResp{}
+				err = resp.Unmarshal(res.([]byte))
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Message == "hello world", resp)
+			})
+			t.Run("ServerStreamingWithSpecifying", func(t *testing.T) {
+				req := &pbapi.MockReq{Message: "hello world"}
+				buf, _ := req.Marshal(nil)
+				stream, err := genericClient.ServerStreaming(context.Background(), "ServerStreamingTest", buf,
+					streamcall.WithBinaryGenericIDLService(serviceName))
+				test.Assert(t, err == nil, err)
+				res, err := stream.Recv(stream.Context())
+				test.Assert(t, err == nil, err)
+				resp := &pbapi.MockResp{}
+				err = resp.Unmarshal(res.([]byte))
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Message == "hello world", resp)
+				_, err = stream.Recv(stream.Context())
+				test.Assert(t, err == io.EOF)
+			})
+		})
+	}
 }

--- a/generic/binarythrift/generic_test.go
+++ b/generic/binarythrift/generic_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/cloudwego/gopkg/protocol/thrift"
 	"github.com/cloudwego/kitex/client"
+	"github.com/cloudwego/kitex/client/callopt"
+	"github.com/cloudwego/kitex/client/callopt/streamcall"
 	"github.com/cloudwego/kitex/pkg/generic"
 	"github.com/cloudwego/kitex/server/genericserver"
 	"github.com/cloudwego/kitex/transport"
@@ -161,5 +163,125 @@ func TestBidiStreaming(t *testing.T) {
 				test.Assert(t, err == io.EOF)
 			})
 		}
+	}
+}
+
+func TestGenericCallWithIDLService(t *testing.T) {
+	protocols := []transport.Protocol{transport.TTHeader, transport.GRPC, transport.GRPCStreaming | transport.TTHeader, transport.TTHeaderStreaming | transport.TTHeader}
+	for _, protocol := range protocols {
+		t.Run(protocol.String(), func(t *testing.T) {
+			// client created with an invalid IDL service name
+			genericClient := newGenericClient(generic.BinaryThriftGenericV2("ClientSideIDLService"),
+				genericAddr.String(), client.WithTransportProtocol(protocol))
+
+			args := tenant.NewEchoServiceEchoArgs()
+			args.Request = &tenant.EchoRequest{Msg: "hello world"}
+			buf := thrift.FastMarshal(args)
+
+			// without WithBinaryGenericIDLService: service name is "ClientSideIDLService", should fail
+			_, err := genericClient.GenericCall(context.Background(), "Echo", buf)
+			test.Assert(t, err != nil)
+
+			// with WithBinaryGenericIDLService: service name overridden to "EchoService", should succeed
+			res, err := genericClient.GenericCall(context.Background(), "Echo", buf,
+				callopt.WithBinaryGenericIDLService(serviceName))
+			test.Assert(t, err == nil, err)
+
+			resp := tenant.NewEchoServiceEchoResult()
+			err = thrift.FastUnmarshal(res.([]byte), resp)
+			test.Assert(t, err == nil)
+			test.Assert(t, resp.Success.Msg == "hello world", resp)
+		})
+	}
+}
+
+func TestStreamingWithIDLService(t *testing.T) {
+	protocols := []transport.Protocol{transport.TTHeaderStreaming | transport.TTHeader, transport.GRPCStreaming | transport.TTHeader, transport.GRPC}
+	for _, protocol := range protocols {
+		t.Run(protocol.String(), func(t *testing.T) {
+			// client created with an invalid IDL service name
+			genericClient := newGenericClient(generic.BinaryThriftGenericV2("ClientSideIDLService"),
+				genericAddr.String(), client.WithTransportProtocol(protocol))
+
+			t.Run("BidiStreamingWithoutSpecifying", func(t *testing.T) {
+				stream, err := genericClient.BidirectionalStreaming(context.Background(), "EchoBidi")
+				test.Assert(t, err == nil, err)
+				req := &tenant.EchoRequest{Msg: "hello world"}
+				buf := thrift.FastMarshal(req)
+				err = stream.Send(stream.Context(), buf)
+				test.Assert(t, err == nil, err)
+				err = stream.CloseSend(stream.Context())
+				test.Assert(t, err == nil, err)
+				_, err = stream.Recv(stream.Context())
+				test.Assert(t, err != nil)
+			})
+			t.Run("BidiStreamingWithSpecifying", func(t *testing.T) {
+				stream, err := genericClient.BidirectionalStreaming(context.Background(), "EchoBidi",
+					streamcall.WithBinaryGenericIDLService(serviceName))
+				test.Assert(t, err == nil, err)
+				req := &tenant.EchoRequest{Msg: "hello world"}
+				buf := thrift.FastMarshal(req)
+				err = stream.Send(stream.Context(), buf)
+				test.Assert(t, err == nil, err)
+				err = stream.CloseSend(stream.Context())
+				test.Assert(t, err == nil, err)
+				res, err := stream.Recv(stream.Context())
+				test.Assert(t, err == nil, err)
+				resp := &tenant.EchoResponse{}
+				err = thrift.FastUnmarshal(res.([]byte), resp)
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Msg == "hello world", resp)
+				_, err = stream.Recv(stream.Context())
+				test.Assert(t, err == io.EOF, err)
+			})
+			t.Run("ClientStreamingWithoutSpecifying", func(t *testing.T) {
+				stream, err := genericClient.ClientStreaming(context.Background(), "EchoClient")
+				test.Assert(t, err == nil, err)
+				req := &tenant.EchoRequest{Msg: "hello world"}
+				buf := thrift.FastMarshal(req)
+				err = stream.Send(stream.Context(), buf)
+				test.Assert(t, err == nil, err)
+				_, err = stream.CloseAndRecv(stream.Context())
+				test.Assert(t, err != nil)
+			})
+			t.Run("ClientStreamingWithSpecifying", func(t *testing.T) {
+				stream, err := genericClient.ClientStreaming(context.Background(), "EchoClient",
+					streamcall.WithBinaryGenericIDLService(serviceName))
+				test.Assert(t, err == nil, err)
+				req := &tenant.EchoRequest{Msg: "hello world"}
+				buf := thrift.FastMarshal(req)
+				err = stream.Send(stream.Context(), buf)
+				test.Assert(t, err == nil, err)
+				res, err := stream.CloseAndRecv(stream.Context())
+				test.Assert(t, err == nil, err)
+				resp := &tenant.EchoResponse{}
+				err = thrift.FastUnmarshal(res.([]byte), resp)
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Msg == "hello world", resp)
+			})
+			t.Run("ServerStreamingWithoutSpecifying", func(t *testing.T) {
+				req := &tenant.EchoRequest{Msg: "hello world"}
+				buf := thrift.FastMarshal(req)
+				stream, err := genericClient.ServerStreaming(context.Background(), "EchoServer", buf)
+				test.Assert(t, err == nil, err)
+				_, err = stream.Recv(stream.Context())
+				test.Assert(t, err != nil)
+			})
+			t.Run("ServerStreamingWithSpecifying", func(t *testing.T) {
+				req := &tenant.EchoRequest{Msg: "hello world"}
+				buf := thrift.FastMarshal(req)
+				stream, err := genericClient.ServerStreaming(context.Background(), "EchoServer", buf,
+					streamcall.WithBinaryGenericIDLService(serviceName))
+				test.Assert(t, err == nil, err)
+				res, err := stream.Recv(stream.Context())
+				test.Assert(t, err == nil, err)
+				resp := &tenant.EchoResponse{}
+				err = thrift.FastUnmarshal(res.([]byte), resp)
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Msg == "hello world", resp)
+				_, err = stream.Recv(stream.Context())
+				test.Assert(t, err == io.EOF, err)
+			})
+		})
 	}
 }

--- a/generic/map/client_test.go
+++ b/generic/map/client_test.go
@@ -245,3 +245,62 @@ func TestGenericServiceImplV2_BidiStreaming(t *testing.T) {
 		})
 	}
 }
+
+// TestWriteDifferentElemTypes tests that writing containers with different element types
+// returns a clean error instead of panic.
+func TestWriteDifferentElemTypes(t *testing.T) {
+	p, err := generic.NewThriftFileProvider("../../idl/tenant.thrift")
+	test.Assert(t, err == nil)
+	g, err := generic.MapThriftGeneric(p)
+	test.Assert(t, err == nil)
+
+	cli, err := newGenericClient("a.b.c", g, client.WithHostPorts(testaddr))
+	test.Assert(t, err == nil)
+
+	t.Run("ListWithMixedTypes", func(t *testing.T) {
+		// list<string> but second element is int32
+		req := map[string]interface{}{
+			"Msg":  "hello",
+			"List": []interface{}{"hello", int32(100)},
+		}
+		_, err := cli.GenericCall(context.Background(), "Echo", req)
+		test.Assert(t, err != nil)
+		t.Log(err)
+	})
+
+	t.Run("SetWithMixedTypes", func(t *testing.T) {
+		// set<string> but second element is int32
+		req := map[string]interface{}{
+			"Msg": "hello",
+			"Set": []interface{}{"hello", int32(100)},
+		}
+		_, err := cli.GenericCall(context.Background(), "Echo", req)
+		test.Assert(t, err != nil)
+		t.Log(err)
+	})
+
+	t.Run("MapWithMixedValueTypes", func(t *testing.T) {
+		// map<string,string> but second value is int32
+		req := map[string]interface{}{
+			"Msg": "hello",
+			"Map": map[interface{}]interface{}{
+				"key1": "value1",
+				"key2": int32(100),
+			},
+		}
+		_, err := cli.GenericCall(context.Background(), "Echo", req)
+		test.Assert(t, err != nil)
+		t.Log(err)
+	})
+
+	t.Run("NilThenNonNilInList", func(t *testing.T) {
+		// list<string> with nil then int32
+		req := map[string]interface{}{
+			"Msg":  "hello",
+			"List": []interface{}{nil, int32(100)},
+		}
+		_, err := cli.GenericCall(context.Background(), "Echo", req)
+		test.Assert(t, err != nil)
+		t.Log(err)
+	})
+}

--- a/streamx/grpc_compat.go
+++ b/streamx/grpc_compat.go
@@ -1,0 +1,300 @@
+// Copyright 2026 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package streamx
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/kitex/client"
+	"github.com/cloudwego/kitex/pkg/endpoint"
+	"github.com/cloudwego/kitex/pkg/endpoint/sep"
+	"github.com/cloudwego/kitex/pkg/streaming"
+	"github.com/cloudwego/kitex/pkg/transmeta"
+	"github.com/cloudwego/kitex/server"
+	"github.com/cloudwego/kitex/transport"
+
+	"github.com/cloudwego/kitex-tests/kitex_gen/protobuf/pbapi"
+	"github.com/cloudwego/kitex-tests/kitex_gen/protobuf/pbapi/mock"
+	"github.com/cloudwego/kitex-tests/kitex_gen/thrift/tenant"
+	"github.com/cloudwego/kitex-tests/kitex_gen/thrift/tenant/echoservice"
+	"github.com/cloudwego/kitex-tests/pkg/test"
+)
+
+type oldStreamMWKey struct{}
+
+// wrappedOldStream simulates a user-wrapped streaming.Stream in old-style endpoint middleware.
+type wrappedOldStream struct {
+	streaming.Stream
+}
+
+type grpcCompatThriftImpl struct {
+	tenant.EchoService
+}
+
+func (s *grpcCompatThriftImpl) Echo(ctx context.Context, req *tenant.EchoRequest) (*tenant.EchoResponse, error) {
+	return &tenant.EchoResponse{Msg: req.Msg}, nil
+}
+
+func (s *grpcCompatThriftImpl) EchoBidi(ctx context.Context, stream tenant.EchoService_EchoBidiServer) error {
+	if ctx.Value(oldStreamMWKey{}) != true {
+		return errors.New("old stream middleware wrapping not preserved in EchoBidi")
+	}
+	for {
+		req, err := stream.Recv(ctx)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err = stream.Send(ctx, &tenant.EchoResponse{Msg: req.Msg}); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *grpcCompatThriftImpl) EchoClient(ctx context.Context, stream tenant.EchoService_EchoClientServer) error {
+	if ctx.Value(oldStreamMWKey{}) != true {
+		return errors.New("old stream middleware wrapping not preserved in EchoClient")
+	}
+	var lastMsg string
+	for {
+		req, err := stream.Recv(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		lastMsg = req.Msg
+	}
+	return stream.SendAndClose(ctx, &tenant.EchoResponse{Msg: lastMsg})
+}
+
+func (s *grpcCompatThriftImpl) EchoServer(ctx context.Context, req *tenant.EchoRequest, stream tenant.EchoService_EchoServerServer) error {
+	if ctx.Value(oldStreamMWKey{}) != true {
+		return errors.New("old stream middleware wrapping not preserved in EchoServer")
+	}
+	return stream.Send(ctx, &tenant.EchoResponse{Msg: req.Msg})
+}
+
+type grpcCompatPbImpl struct{}
+
+func (s *grpcCompatPbImpl) UnaryTest(ctx context.Context, req *pbapi.MockReq) (*pbapi.MockResp, error) {
+	return &pbapi.MockResp{Message: req.Message}, nil
+}
+
+func (s *grpcCompatPbImpl) BidirectionalStreamingTest(ctx context.Context, stream pbapi.Mock_BidirectionalStreamingTestServer) error {
+	if ctx.Value(oldStreamMWKey{}) != true {
+		return errors.New("old stream middleware wrapping not preserved")
+	}
+	for {
+		req, err := stream.Recv(ctx)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err = stream.Send(ctx, &pbapi.MockResp{Message: req.Message}); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *grpcCompatPbImpl) ClientStreamingTest(ctx context.Context, stream pbapi.Mock_ClientStreamingTestServer) error {
+	if ctx.Value(oldStreamMWKey{}) != true {
+		return errors.New("old stream middleware wrapping not preserved")
+	}
+	var lastMsg string
+	for {
+		req, err := stream.Recv(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		lastMsg = req.Message
+	}
+	return stream.SendAndClose(ctx, &pbapi.MockResp{Message: lastMsg})
+}
+
+func (s *grpcCompatPbImpl) ServerStreamingTest(ctx context.Context, req *pbapi.MockReq, stream pbapi.Mock_ServerStreamingTestServer) error {
+	if ctx.Value(oldStreamMWKey{}) != true {
+		return errors.New("old stream middleware wrapping not preserved")
+	}
+	return stream.Send(ctx, &pbapi.MockResp{Message: req.Message})
+}
+
+// RunGRPCCompatServer creates a server with old-style endpoint middleware that wraps
+// streaming.Args.Stream. This tests the fix that the wrapped stream is preserved
+// (not discarded) when passed to the stream handler endpoint.
+func RunGRPCCompatServer(listenAddr string) server.Server {
+	addr, _ := net.ResolveTCPAddr("tcp", listenAddr)
+	svr := echoservice.NewServer(&grpcCompatThriftImpl{},
+		server.WithServiceAddr(addr),
+		server.WithExitWaitTime(1*time.Second),
+		server.WithMetaHandler(transmeta.ServerTTHeaderHandler),
+		server.WithMetaHandler(transmeta.ServerHTTP2Handler),
+		// old-style endpoint middleware: wraps streaming.Args.Stream
+		server.WithMiddleware(func(next endpoint.Endpoint) endpoint.Endpoint {
+			return func(ctx context.Context, req, resp interface{}) error {
+				if args, ok := req.(*streaming.Args); ok && args.Stream != nil {
+					args.Stream = &wrappedOldStream{Stream: args.Stream}
+				}
+				return next(ctx, req, resp)
+			}
+		}),
+		// stream middleware: verifies the wrapped stream is preserved via GRPCStreamGetter
+		server.WithStreamOptions(server.WithStreamMiddleware(func(next sep.StreamEndpoint) sep.StreamEndpoint {
+			return func(ctx context.Context, stream streaming.ServerStream) error {
+				if getter, ok := stream.(streaming.GRPCStreamGetter); ok {
+					st := getter.GetGRPCStream()
+					if _, ok := st.(*wrappedOldStream); ok {
+						ctx = context.WithValue(ctx, oldStreamMWKey{}, true)
+					}
+				}
+				return next(ctx, stream)
+			}
+		})),
+	)
+	if err := mock.RegisterService(svr, &grpcCompatPbImpl{}); err != nil {
+		panic(err)
+	}
+	go func() {
+		if err := svr.Run(); err != nil {
+			println(err)
+		}
+	}()
+	return svr
+}
+
+// TestThriftGRPCCompat tests that old-style endpoint middleware wrapping streaming.Args.Stream
+// is preserved and accessible in the stream middleware chain for thrift streaming calls.
+func TestThriftGRPCCompat(t *testing.T, addr string) {
+	testcases := []struct {
+		desc string
+		prot transport.Protocol
+	}{
+		{"GRPCStreaming", transport.TTHeader | transport.GRPCStreaming},
+		{"GRPC", transport.GRPC},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			cli := echoservice.MustNewClient("service",
+				client.WithHostPorts(addr),
+				client.WithTransportProtocol(tc.prot),
+				client.WithMetaHandler(transmeta.ClientHTTP2Handler),
+				client.WithMetaHandler(transmeta.ClientTTHeaderHandler),
+			)
+			t.Run("BidiStreaming", func(t *testing.T) {
+				ctx := context.Background()
+				stream, err := cli.EchoBidi(ctx)
+				test.Assert(t, err == nil, err)
+				err = stream.Send(ctx, &tenant.EchoRequest{Msg: "ping"})
+				test.Assert(t, err == nil, err)
+				err = stream.CloseSend(ctx)
+				test.Assert(t, err == nil, err)
+				resp, err := stream.Recv(ctx)
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Msg == "ping", resp.Msg)
+				_, err = stream.Recv(ctx)
+				test.Assert(t, err == io.EOF)
+			})
+			t.Run("ClientStreaming", func(t *testing.T) {
+				ctx := context.Background()
+				stream, err := cli.EchoClient(ctx)
+				test.Assert(t, err == nil, err)
+				err = stream.Send(ctx, &tenant.EchoRequest{Msg: "ping"})
+				test.Assert(t, err == nil, err)
+				resp, err := stream.CloseAndRecv(ctx)
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Msg == "ping", resp.Msg)
+			})
+			t.Run("ServerStreaming", func(t *testing.T) {
+				ctx := context.Background()
+				stream, err := cli.EchoServer(ctx, &tenant.EchoRequest{Msg: "ping"})
+				test.Assert(t, err == nil, err)
+				resp, err := stream.Recv(ctx)
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Msg == "ping", resp.Msg)
+				_, err = stream.Recv(ctx)
+				test.Assert(t, err == io.EOF)
+			})
+		})
+	}
+}
+
+// TestPbGRPCCompat tests that old-style endpoint middleware wrapping streaming.Args.Stream
+// is preserved and accessible in the stream middleware chain for pb streaming calls.
+func TestPbGRPCCompat(t *testing.T, addr string) {
+	testcases := []struct {
+		desc string
+		prot transport.Protocol
+	}{
+		{"GRPCStreaming", transport.TTHeader | transport.GRPCStreaming},
+		{"GRPC", transport.GRPC},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			cli := mock.MustNewClient("service",
+				client.WithHostPorts(addr),
+				client.WithTransportProtocol(tc.prot),
+				client.WithMetaHandler(transmeta.ClientHTTP2Handler),
+				client.WithMetaHandler(transmeta.ClientTTHeaderHandler),
+			)
+			t.Run("BidiStreaming", func(t *testing.T) {
+				ctx := context.Background()
+				stream, err := cli.BidirectionalStreamingTest(ctx)
+				test.Assert(t, err == nil, err)
+				err = stream.Send(ctx, &pbapi.MockReq{Message: "ping"})
+				test.Assert(t, err == nil, err)
+				err = stream.CloseSend(ctx)
+				test.Assert(t, err == nil, err)
+				resp, err := stream.Recv(ctx)
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Message == "ping", resp.Message)
+				_, err = stream.Recv(ctx)
+				test.Assert(t, err == io.EOF)
+			})
+			t.Run("ClientStreaming", func(t *testing.T) {
+				ctx := context.Background()
+				stream, err := cli.ClientStreamingTest(ctx)
+				test.Assert(t, err == nil, err)
+				err = stream.Send(ctx, &pbapi.MockReq{Message: "ping"})
+				test.Assert(t, err == nil, err)
+				resp, err := stream.CloseAndRecv(ctx)
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Message == "ping", resp.Message)
+			})
+			t.Run("ServerStreaming", func(t *testing.T) {
+				ctx := context.Background()
+				stream, err := cli.ServerStreamingTest(ctx, &pbapi.MockReq{Message: "ping"})
+				test.Assert(t, err == nil, err)
+				resp, err := stream.Recv(ctx)
+				test.Assert(t, err == nil, err)
+				test.Assert(t, resp.Message == "ping", resp.Message)
+				_, err = stream.Recv(ctx)
+				test.Assert(t, err == io.EOF)
+			})
+		})
+	}
+}

--- a/streamx/normal.go
+++ b/streamx/normal.go
@@ -767,7 +767,7 @@ func commonTestNormal[Req, Res any](t *testing.T, cli normalClient[Req, Res], cl
 	ctx = metadata.AppendToOutgoingContext(ctx, "metadatakey", "metadatavalue")
 
 	_, err := cli.EchoUnary(ctx, reqGetter("test_unary_timeout"))
-	test.Assert(t, kerrors.IsTimeoutError(err))
+	test.Assert(t, kerrors.IsTimeoutError(err), err)
 
 	// test unary middleware
 	a, b, c, d, e, f, g, h = 0, 0, 0, 0, 0, 0, 0, 0

--- a/streamx/proto/proto_test.go
+++ b/streamx/proto/proto_test.go
@@ -26,17 +26,19 @@ import (
 )
 
 var (
-	pbTestAddr    string
-	pbCancelAddr  string
-	pbTimeoutAddr string
+	pbTestAddr       string
+	pbCancelAddr     string
+	pbTimeoutAddr    string
+	pbGRPCCompatAddr string
 )
 
 func TestMain(m *testing.M) {
 	var normalSrv server.Server
 	var cancelSrv server.Server
 	var timeoutSrv server.Server
+	var grpcCompatSrv server.Server
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(4)
 	go func() {
 		defer wg.Done()
 		pbTestAddr = serverutils.NextListenAddr()
@@ -55,11 +57,18 @@ func TestMain(m *testing.M) {
 		timeoutSrv = streamx.RunTestTimeoutServer(pbTimeoutAddr)
 		serverutils.Wait(pbTimeoutAddr)
 	}()
+	go func() {
+		defer wg.Done()
+		pbGRPCCompatAddr = serverutils.NextListenAddr()
+		grpcCompatSrv = streamx.RunGRPCCompatServer(pbGRPCCompatAddr)
+		serverutils.Wait(pbGRPCCompatAddr)
+	}()
 	wg.Wait()
 	m.Run()
 	normalSrv.Stop()
 	cancelSrv.Stop()
 	timeoutSrv.Stop()
+	grpcCompatSrv.Stop()
 	log.Print("streamx pb test finished")
 }
 
@@ -73,4 +82,8 @@ func TestCancel(t *testing.T) {
 
 func TestTimeout(t *testing.T) {
 	streamx.TestPbTimeout(t, pbTimeoutAddr)
+}
+
+func TestGRPCCompat(t *testing.T) {
+	streamx.TestPbGRPCCompat(t, pbGRPCCompatAddr)
 }

--- a/streamx/thrift/thrift_test.go
+++ b/streamx/thrift/thrift_test.go
@@ -26,17 +26,19 @@ import (
 )
 
 var (
-	thriftTestAddr        string
-	thriftTestCancelAddr  string
-	thriftTestTimeoutAddr string
+	thriftTestAddr            string
+	thriftTestCancelAddr      string
+	thriftTestTimeoutAddr     string
+	thriftGRPCCompatAddr      string
 )
 
 func TestMain(m *testing.M) {
 	var normalSrv server.Server
 	var cancelSrv server.Server
 	var timeoutSrv server.Server
+	var grpcCompatSrv server.Server
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(4)
 	go func() {
 		defer wg.Done()
 		thriftTestAddr = serverutils.NextListenAddr()
@@ -55,11 +57,18 @@ func TestMain(m *testing.M) {
 		timeoutSrv = streamx.RunTestTimeoutServer(thriftTestTimeoutAddr)
 		serverutils.Wait(thriftTestTimeoutAddr)
 	}()
+	go func() {
+		defer wg.Done()
+		thriftGRPCCompatAddr = serverutils.NextListenAddr()
+		grpcCompatSrv = streamx.RunGRPCCompatServer(thriftGRPCCompatAddr)
+		serverutils.Wait(thriftGRPCCompatAddr)
+	}()
 	wg.Wait()
 	m.Run()
 	normalSrv.Stop()
 	cancelSrv.Stop()
 	timeoutSrv.Stop()
+	grpcCompatSrv.Stop()
 	log.Print("streamx thrift test finished")
 }
 
@@ -73,4 +82,8 @@ func TestCancel(t *testing.T) {
 
 func TestTimeout(t *testing.T) {
 	streamx.TestThriftTimeout(t, thriftTestTimeoutAddr)
+}
+
+func TestGRPCCompat(t *testing.T) {
+	streamx.TestThriftGRPCCompat(t, thriftGRPCCompatAddr)
 }


### PR DESCRIPTION
#### What type of PR is this?
test
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 
补充以下三个 Feat/Fix 的集成测试：
1. 修复泛化 Write 元素类型不同的容器导致的 panic 问题 https://github.com/cloudwego/kitex/pull/1926
2. 二进制泛化调用支持动态指定 IDL Service https://github.com/cloudwego/kitex/pull/1928
3. 修复老流式接口通过 Server MW wrap Stream 扩展失效的问题 https://github.com/cloudwego/kitex/pull/1929


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
